### PR TITLE
release(global): v0.4.0

### DIFF
--- a/.changeset/shaggy-apes-develop.md
+++ b/.changeset/shaggy-apes-develop.md
@@ -1,0 +1,8 @@
+---
+"@productplan/atlas-docs": minor
+"@productplan/atlas": minor
+"@productplan/atlas-styles": minor
+"@productplan/atlas-web-components": minor
+---
+
+add new wc wrapper without the shadow dom

--- a/.changeset/shaggy-apes-develop.md
+++ b/.changeset/shaggy-apes-develop.md
@@ -1,8 +1,0 @@
----
-"@productplan/atlas-docs": minor
-"@productplan/atlas": minor
-"@productplan/atlas-styles": minor
-"@productplan/atlas-web-components": minor
----
-
-add new wc wrapper without the shadow dom

--- a/.cz-config.js
+++ b/.cz-config.js
@@ -25,7 +25,7 @@ module.exports = {
     { value: 'POC', name: 'POC:      Proof of Concept' },
   ],
 
-  scopes: [{ name: 'global' }, { name: 'atlas-docs' }, { name: 'atlas-react' }, { name: 'atlas-tokens' }, { name: 'atlas-web-components' }],
+  scopes: [{ name: 'global' }, { name: 'atlas-docs' }, { name: 'atlas-react' }, , { name: 'atlas-styles' }, { name: 'atlas-tokens' }, { name: 'atlas-web-components' }],
 
   allowTicketNumber: true,
   isTicketNumberRequired: false,

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @productplan/atlas-docs
 
+## 0.4.0
+
+### Minor Changes
+
+- c6e6644: add new wc wrapper without the shadow dom
+
+### Patch Changes
+
+- Updated dependencies [c6e6644]
+  - @productplan/atlas@0.4.0
+  - @productplan/atlas-web-components@0.4.0
+
 ## 0.3.2
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@productplan/atlas-docs",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/packages/atlas-react/CHANGELOG.md
+++ b/packages/atlas-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @productplan/atlas
 
+## 0.4.0
+
+### Minor Changes
+
+- c6e6644: add new wc wrapper without the shadow dom
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/atlas-react/package.json
+++ b/packages/atlas-react/package.json
@@ -2,7 +2,7 @@
   "author": "ProductPlan <dev@productplan.com>",
   "name": "@productplan/atlas",
   "homepage": "https://github.com/ProductPlan/atlas",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "sideEffects": false,

--- a/packages/atlas-styles/CHANGELOG.md
+++ b/packages/atlas-styles/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @productplan/atlas-styles
+
+## 0.2.0
+
+### Minor Changes
+
+- c6e6644: add new wc wrapper without the shadow dom

--- a/packages/atlas-styles/package.json
+++ b/packages/atlas-styles/package.json
@@ -2,7 +2,7 @@
   "author": "ProductPlan <dev@productplan.com>",
   "name": "@productplan/atlas-styles",
   "homepage": "https://github.com/ProductPlan/atlas",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "main": "atlas.scss",
   "private": true,
   "license": "MIT",

--- a/packages/atlas-styles/package.json
+++ b/packages/atlas-styles/package.json
@@ -2,7 +2,7 @@
   "author": "ProductPlan <dev@productplan.com>",
   "name": "@productplan/atlas-styles",
   "homepage": "https://github.com/ProductPlan/atlas",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "atlas.scss",
   "private": true,
   "license": "MIT",

--- a/packages/atlas-web-components/CHANGELOG.md
+++ b/packages/atlas-web-components/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @productplan/atlas-web-components
 
+## 0.4.0
+
+### Minor Changes
+
+- c6e6644: add new wc wrapper without the shadow dom
+
+### Patch Changes
+
+- Updated dependencies [c6e6644]
+  - @productplan/atlas-styles@0.2.0
+
 ## 0.3.1
 
 ### Patch Changes

--- a/packages/atlas-web-components/package.json
+++ b/packages/atlas-web-components/package.json
@@ -3,7 +3,7 @@
   "name": "@productplan/atlas-web-components",
   "homepage": "https://github.com/ProductPlan/atlas",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "yarn run build:lib",


### PR DESCRIPTION
## Release 0.4.0

- New version, `0.4.0`
- New WC wrapper (without the `shadow dom`)
- New package `@productplan/atlas-styles`