### PR TITLE
fix: [#184490617] fix bad camel case in htmlId attribute

### DIFF
--- a/packages/atlas-react/src/components/BasicButton/BasicButton.js
+++ b/packages/atlas-react/src/components/BasicButton/BasicButton.js
@@ -38,7 +38,7 @@ export default function BasicButton({
       // create a unique key to force re-rendering of the component
       key={`${label}-${htmlId}-${onClick}-${align}-${disabled}-${htmlType}-${leadingIcon}-${size}-${trailingIcon}-${type}`}
       align={align}
-      htmlId={htmlId}
+      htmlid={htmlId}
       label={label}
       size={size}
       theme={type}

--- a/packages/atlas-web-components/src/components/BasicButton.jsx
+++ b/packages/atlas-web-components/src/components/BasicButton.jsx
@@ -5,7 +5,7 @@ import "./BasicButton.scss";
 const BasicButton = ({
   align = "center",
   disabled = undefined,
-  htmlId = undefined,
+  htmlid = undefined,
   label = "",
   leadingIcon = null,
   size = "default",
@@ -18,7 +18,7 @@ const BasicButton = ({
       <button
         className={`BasicButton BasicButton--${theme} BasicButton--size-${size} BasicButton--align-${align}`}
         type={type}
-        id={htmlId}
+        id={htmlid}
         disabled={disabled}
         size={size}
       >
@@ -30,4 +30,4 @@ const BasicButton = ({
   );
 };
 
-define('atlas-basic-button', () => BasicButton, { attributes: ['align', 'disabled', 'htmlId', 'label', 'size', 'theme', 'type']})
+define('atlas-basic-button', () => BasicButton, { attributes: ['align', 'disabled', 'htmlid', 'label', 'size', 'theme', 'type']})


### PR DESCRIPTION
html attributes need to be all lowercase to avoid a render issue we found in the test suite.